### PR TITLE
fix: ignore peer dependencies of root package

### DIFF
--- a/src/packageUtils.ts
+++ b/src/packageUtils.ts
@@ -93,7 +93,9 @@ export function walkPackageDependencyTree(packagePath: string, isAncestorDevDepe
     packageDependencies.peerDependencies.forEach(dep => console.log(dep))
   }
 
-  visitor(packagePath, packageJson, packageDependencies);
+  if (!isRootPackage) {
+    visitor(packagePath, packageJson, packageDependencies);
+  }
 
   function walkDependency(dependency: Dependency, isAncestorDevDependency: boolean) {
     if (resolve.isCore(dependency.name)) {


### PR DESCRIPTION
This change will ignore the check for peerDependencies of the root package. Only consumers of this package should be checked for this peerDependency, not the package itself.

[peerDependencies](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependencies)
> In some cases, you want to express the compatibility of your package with a host tool or library, while not necessarily doing a require of this host. This is usually referred to as a plugin. Notably, your module may be exposing a specific interface, expected and specified by the host documentation.

Usecase
You are creating a library relying on react 18, but you don't want to bundle react, so you define a peerDependency. It will not pass check-peer-dependencies.

Reproduction
Add this to this project's package.json on the master branch (v4.3.0):

```json
  "peerDependencies": {
    "react": "18.2.0"
  }
```

```sh
npm run build
node dist/cli.js
```

It will fail because the package itself requires react to be installed. While a peerDependency signals that the consumer of the package shoul satisify the installation of the peerDependency. Not the package itself.

NOTE: bumped version by a major version as this reduces strictness on which consumers of this package may rely on